### PR TITLE
Refactor : OAuth2-Session 과제 1번 구현

### DIFF
--- a/OAuth2Session/src/main/java/com/Spring/OAuthSession/oauth2/CustomJdbcOAuth2AuthorizedClientService.java
+++ b/OAuth2Session/src/main/java/com/Spring/OAuthSession/oauth2/CustomJdbcOAuth2AuthorizedClientService.java
@@ -1,36 +1,99 @@
-//추후 작성 예정
+package com.Spring.OAuthSession.oauth2;
 
-/*package com.Spring.OAuthSession.oauth2;
-
+import com.Spring.OAuthSession.dto.CustomOAuth2User;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcOperations;
-import org.springframework.jdbc.support.lob.LobHandler;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.JdbcOAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.jdbc.core.SqlParameterValue;
 
-public class CustomJdbcOAuth2AuthorizedClientService extends JdbcOAuth2AuthorizedClientService {
+import org.springframework.util.Assert;
+import java.util.List;
 
-    public CustomJdbcOAuth2AuthorizedClientService(JdbcOperations jdbcOperations, ClientRegistrationRepository clientRegistrationRepository) {
-        super(jdbcOperations, clientRegistrationRepository);
-    }
+@RequiredArgsConstructor
+public class CustomJdbcOAuth2AuthorizedClientService implements OAuth2AuthorizedClientService {
 
-    public CustomJdbcOAuth2AuthorizedClientService(JdbcOperations jdbcOperations, ClientRegistrationRepository clientRegistrationRepository, LobHandler lobHandler) {
-        super(jdbcOperations, clientRegistrationRepository, lobHandler);
-    }
+    private static final String INSERT_CLIENT_SQL =
+            "INSERT INTO oauth2_authorized_client (client_registration_id, principal_name, access_token_type, access_token_value, access_token_issued_at, access_token_expires_at, access_token_scopes, refresh_token_value, refresh_token_issued_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+    private static final String UPDATE_CLIENT_SQL =
+            "UPDATE oauth2_authorized_client SET access_token_type = ?, access_token_value = ?, access_token_issued_at = ?, access_token_expires_at = ?, access_token_scopes = ?, refresh_token_value = ?, refresh_token_issued_at = ? WHERE client_registration_id = ? AND principal_name = ?";
+
+    private static final String DELETE_CLIENT_SQL =
+            "DELETE FROM oauth2_authorized_client WHERE client_registration_id = ? AND principal_name = ?";
+
+    private static final String SELECT_CLIENT_SQL =
+            "SELECT * FROM oauth2_authorized_client WHERE client_registration_id = ? AND principal_name = ?";
+
+    private final JdbcOperations jdbcOperations;
+    private final ClientRegistrationRepository clientRegistrationRepository;
 
     @Override
     public <T extends OAuth2AuthorizedClient> T loadAuthorizedClient(String clientRegistrationId, String principalName) {
-        return super.loadAuthorizedClient(clientRegistrationId, principalName);
+
+        Assert.hasText(clientRegistrationId, "clientRegistrationId에 문자열 값이 없습니다.");
+        Assert.hasText(principalName, "principalName에 문자열 값이 없습니다.");
+
+        List<OAuth2AuthorizedClient> results = jdbcOperations.query(SELECT_CLIENT_SQL,
+                new Object[]{clientRegistrationId, principalName}, // SQL에 들어갈 파라미터 배열 선언
+                new JdbcOAuth2AuthorizedClientService.OAuth2AuthorizedClientRowMapper(clientRegistrationRepository));
+                // ↑ : 쿼리 결과로 나온 ResultSet을 OAuth2AuthorizedClient로 변환해주는 RowMapper 객체를 생성
+
+        return results.isEmpty() ? null : (T) results.get(0);
+
     }
 
     @Override
     public void saveAuthorizedClient(OAuth2AuthorizedClient authorizedClient, Authentication principal) {
-        super.saveAuthorizedClient(authorizedClient, principal);
+
+        Assert.notNull(authorizedClient, "authorizedClient은 Null이면 안됩니다.");
+        Assert.notNull(principal, "principal은 Null이면 안됩니다.");
+
+        CustomOAuth2User customOAuth2User = (CustomOAuth2User) principal.getPrincipal();
+        String username = customOAuth2User.getUsername();
+
+        boolean existsClient = null != loadAuthorizedClient(authorizedClient.getClientRegistration().getRegistrationId(), username);
+
+        if (existsClient) {
+            updateAuthorizedClient(authorizedClient, username);
+        } else {
+            try {
+                insertAuthorizedClient(authorizedClient, username);
+            } catch (DuplicateKeyException e) {
+                updateAuthorizedClient(authorizedClient, username);
+            }
+        }
+
+    }
+
+
+    protected void insertAuthorizedClient(OAuth2AuthorizedClient authorizedClient, String username) {
+
+        List<SqlParameterValue> parameters = SqlParameters.getInsertParameters(authorizedClient, username);
+        jdbcOperations.update(INSERT_CLIENT_SQL, parameters.toArray());
+
+    }
+
+    protected void updateAuthorizedClient(OAuth2AuthorizedClient authorizedClient, String username) {
+
+        List<SqlParameterValue> parameterValues = SqlParameters.getUpdateParameters(authorizedClient, username);
+        jdbcOperations.update(UPDATE_CLIENT_SQL, parameterValues.toArray());
+
     }
 
     @Override
-    public void removeAuthorizedClient(String clientRegistrationId, String principalName) {
-        super.removeAuthorizedClient(clientRegistrationId, principalName);
+    public void removeAuthorizedClient(String clientRegistrationId, String username) {
+
+        Assert.hasText(clientRegistrationId, "clientRegistrationId에 문자열 값이 없습니다.");
+        Assert.hasText(username, "username에 문자열 값이 없습니다.");
+
+        List<SqlParameterValue> parameters = SqlParameters.getDeleteParameters(clientRegistrationId, username);
+        jdbcOperations.update(DELETE_CLIENT_SQL, parameters.toArray());
+
     }
-}*/
+}

--- a/OAuth2Session/src/main/java/com/Spring/OAuthSession/oauth2/CustomOAuth2AuthorizedClientService.java
+++ b/OAuth2Session/src/main/java/com/Spring/OAuthSession/oauth2/CustomOAuth2AuthorizedClientService.java
@@ -12,7 +12,8 @@ public class CustomOAuth2AuthorizedClientService {
 
     public OAuth2AuthorizedClientService oAuth2AuthorizedClientService(JdbcTemplate jdbcTemplate, ClientRegistrationRepository clientRegistrationRepository) {
 
-        return new JdbcOAuth2AuthorizedClientService(jdbcTemplate, clientRegistrationRepository); //jdbcTemplate을 통해 SQL문으로 DB의 토큰 정보를 CRUD 한다.
+     //   return new JdbcOAuth2AuthorizedClientService(jdbcTemplate, clientRegistrationRepository); //jdbcTemplate을 통해 SQL문으로 DB의 토큰 정보를 CRUD 한다.
+        return new CustomJdbcOAuth2AuthorizedClientService(jdbcTemplate, clientRegistrationRepository);
     }
 
 }

--- a/OAuth2Session/src/main/java/com/Spring/OAuthSession/oauth2/SqlParameters.java
+++ b/OAuth2Session/src/main/java/com/Spring/OAuthSession/oauth2/SqlParameters.java
@@ -1,0 +1,89 @@
+package com.Spring.OAuthSession.oauth2;
+
+import org.springframework.util.CollectionUtils;
+import org.springframework.jdbc.core.SqlParameterValue;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.util.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SqlParameters {
+
+    public static List<SqlParameterValue> getInsertParameters(OAuth2AuthorizedClient authorizedClient, String username) {
+
+        List<SqlParameterValue> parameters = new ArrayList<>();
+        ClientRegistration clientRegistration = authorizedClient.getClientRegistration();
+        OAuth2AccessToken accessToken = authorizedClient.getAccessToken();
+        OAuth2RefreshToken refreshToken = authorizedClient.getRefreshToken();
+
+        parameters.add(new SqlParameterValue(12, clientRegistration.getRegistrationId()));
+        parameters.add(new SqlParameterValue(12, username));
+        parameters.add(new SqlParameterValue(12, accessToken.getTokenType().getValue())); //Bearer
+        parameters.add(new SqlParameterValue(2004, accessToken.getTokenValue().getBytes(StandardCharsets.UTF_8)));
+        parameters.add(new SqlParameterValue(93, Timestamp.from(accessToken.getIssuedAt())));
+        parameters.add(new SqlParameterValue(93, Timestamp.from(accessToken.getExpiresAt())));
+
+        //Scope : Access Token이 접근할 수 있는 자원 범위
+        String accessTokenScopes = CollectionUtils.isEmpty(accessToken.getScopes()) ? null
+                : StringUtils.collectionToDelimitedString(accessToken.getScopes(), ",");
+        //StringUtils.collectionToDelimitedString : Scope의 Collection을 쉼표(,)로 구분된 문자열로 변환
+        parameters.add(new SqlParameterValue(12, accessTokenScopes));
+
+        byte[] refreshTokenValue = refreshToken != null ? refreshToken.getTokenValue().getBytes(StandardCharsets.UTF_8) : null;
+        parameters.add(new SqlParameterValue(2004, refreshTokenValue));
+
+        Timestamp refreshTokenIssuedAt = (refreshToken != null && refreshToken.getIssuedAt() != null) ?
+                Timestamp.from(refreshToken.getIssuedAt()) : null;
+        parameters.add(new SqlParameterValue(93, refreshTokenIssuedAt));
+
+        return parameters;
+
+    }
+
+    public static List<SqlParameterValue> getUpdateParameters(OAuth2AuthorizedClient authorizedClient, String username) {
+
+        List<SqlParameterValue> parameters = new ArrayList<>();
+        OAuth2AccessToken accessToken = authorizedClient.getAccessToken();
+        OAuth2RefreshToken refreshToken = authorizedClient.getRefreshToken();
+
+        parameters.add(new SqlParameterValue(12, accessToken.getTokenType().getValue())); //Bearer
+        parameters.add(new SqlParameterValue(2004, accessToken.getTokenValue().getBytes(StandardCharsets.UTF_8)));
+        parameters.add(new SqlParameterValue(93, Timestamp.from(accessToken.getIssuedAt())));
+        parameters.add(new SqlParameterValue(93, Timestamp.from(accessToken.getExpiresAt())));
+
+        //Scope : Access Token이 접근할 수 있는 자원 범위
+        String accessTokenScopes = CollectionUtils.isEmpty(accessToken.getScopes()) ? null
+                : StringUtils.collectionToDelimitedString(accessToken.getScopes(), ",");
+        //StringUtils.collectionToDelimitedString : Scope의 Collection을 쉼표(,)로 구분된 문자열로 변환
+        parameters.add(new SqlParameterValue(12, accessTokenScopes));
+
+        byte[] refreshTokenValue = refreshToken != null ? refreshToken.getTokenValue().getBytes(StandardCharsets.UTF_8) : null;
+        parameters.add(new SqlParameterValue(2004, refreshTokenValue));
+
+        Timestamp refreshTokenIssuedAt = (refreshToken != null && refreshToken.getIssuedAt() != null) ?
+                Timestamp.from(refreshToken.getIssuedAt()) : null;
+        parameters.add(new SqlParameterValue(93, refreshTokenIssuedAt));
+
+        parameters.add(new SqlParameterValue(12, authorizedClient.getClientRegistration().getRegistrationId())); //WHERE 절
+        parameters.add(new SqlParameterValue(12, username));// WHERE 절
+
+        return parameters;
+
+    }
+
+    public static List<SqlParameterValue> getDeleteParameters(String clientRegistrationId, String principalName) {
+
+        List<SqlParameterValue> parameters = new ArrayList<>();
+
+        parameters.add(new SqlParameterValue(12, clientRegistrationId));
+        parameters.add(new SqlParameterValue(12, principalName));
+
+        return parameters;
+    }
+}

--- a/OAuth2Session/src/main/resources/application.yml
+++ b/OAuth2Session/src/main/resources/application.yml
@@ -38,7 +38,12 @@ spring:
             token-uri: https://nid.naver.com/oauth2.0/token
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
-#
+
 #logging:
 #  level:
-#    root: trace
+#   root: trace
+
+#logging:
+#  level:
+#    org.springframework.jdbc.core: DEBUG
+#    org.springframework.jdbc.core.JdbcTemplate: DEBUG


### PR DESCRIPTION
동일한 이름을 갖는 사용자들로 인해 세션을 덮어 씌우게 되는 문제 현상을 해결 : 

principal_name 에 저장되는 값을 해당 계정의 소유자 이름이 아닌 username(인증 서버에서 보내준 providerId)으로 해결

기존의 서비스인 JdbcOAuth2AuthorizedClientService을 커스텀 하여 진행 